### PR TITLE
fix: link routing to client and lib directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Distributing an airdrop to users is simple if you already have their public keys
 
 This repo demonstrates a strategy for distributing tokens where users can provide a message (known as the 'commitment') over a public channel and later claim their portion of the airdrop by providing a zero-knowledge proof that they belong in the Merkle tree. Claiming tokens in this manner mixes them with all other users entitled to an airdrop, protecting their anonymity.
 
-A self-contained library for generating claim proofs and interacting with these contracts can be found at [a16z/zkdrops/zkdrops-lib](https://github.com/a16z/zkdrops/lib), and an example front-end can be found at [a16z/zkdrops/client-ex](https://github.com/a16z/zkdrops/client-ex).
+A self-contained library for generating claim proofs and interacting with these contracts can be found at [a16z/zkdrops/zkdrops-lib](zkdrops-lib/), and an example front-end can be found at [a16z/zkdrops/client-ex](client-ex/).
 
 The smart contract for distributions (`zkdrops-contracts/contracts/PrivateAirdrop.sol`) includes an `updateRoot` function which allows the owner to modify the Merkle tree after launch, but can be made immutable by removing that function if desired.
 

--- a/client-ex/README.md
+++ b/client-ex/README.md
@@ -1,5 +1,5 @@
 # client-ex: React + NextJS + Webpacking
-Example of computing proofs for the [zkdrops-contracts](https://github.com/a16z/zkdrops/zkdrops-contracts) sample repo in the browser. The majority of the work is done by the [zkdrops-lib](https://github.com/a16z/zkdrops/zkdrops-lib) which in turn uses the work of the iden3 team's Circom libraries. 
+Example of computing proofs for the [zkdrops-contracts](/zkdrops-contracts) sample repo in the browser. The majority of the work is done by the [zkdrops-lib](/zkdrops-lib) which in turn uses the work of the iden3 team's Circom libraries. 
 
 Proof computation takes 20-60s in the browser depending on the machine.
 

--- a/zkdrops-lib/README.md
+++ b/zkdrops-lib/README.md
@@ -1,5 +1,5 @@
 # Zk Merkle Airdrop Library
-Self-contained repo for interacting with the [zkdrops-contracts](https://github.com/a16z/zkdrops/zkdrops-contracts). A browser usage example of this library can be found in [zkdrops/client-ex](https://github.com/a16z/zkdrops/client-ex).
+Self-contained repo for interacting with the [zkdrops-contracts](/zkdrops-contracts). A browser usage example of this library can be found in [zkdrops/client-ex](/client-ex).
 
 ## Usage
 ### Create MerkleTree from file ([ex file](https://github.com/a16z/zkdrops/zkdrops-contracts/blob/master/test/data/mt_8192.txt))


### PR DESCRIPTION
Previous links were broken - replacing them with relative links to the directories