### PR TITLE
typo-Update README.md

### DIFF
--- a/zkdrops-lib/README.md
+++ b/zkdrops-lib/README.md
@@ -35,7 +35,7 @@ import { MerkleTree, poseidon2, generateProofCallData } from 'zkdrops-lib';
 
 let KEY = "0x00d8d681994b73f635532cc3f0a7e3f02e10d55a6e107e1bd374b1c23bead940";
 let SEC = "0x00b87f2a60e72cc5c6f334833c56aaed80aef550b76bd94837a86070c10dd061";
-let airdropToAddress = "0x0"; // Reciever address -- caller of PrivateAirdrop.collectAirdrop()
+let airdropToAddress = "0x0"; // Receiver address -- caller of PrivateAirdrop.collectAirdrop()
 
 // Optional: Compute commitment
 let commitment: BigInt = poseidon2(BigInt(KEY), BigInt(SEC));


### PR DESCRIPTION
# Fix: Corrected typo in README.md

## Changes
1. **File**: `zkdrops-lib/README.md`
   - Corrected "Reciever" to "Receiver".

   - **Before**:
     ```markdown
          Reciever 
     ```
   - **After**:
     ```markdown
         Receiver 
     ```

## Purpose
- Improved documentation accuracy by fixing the typographical error.
- Enhanced the clarity and professionalism of the README file.
